### PR TITLE
Simplify IterNext to use relative stack offsets

### DIFF
--- a/src/backend/vm/bytecode.rs
+++ b/src/backend/vm/bytecode.rs
@@ -50,7 +50,7 @@ gen_bytecode!(
     NewLoopCtx,
     // gets a value from an iterable and pushes it to the stack
     // if the iterable is exhausted, jumps to the end of the loop
-    IterNext, // u16 (jump if end), u16 (loopctx index), loopctx+ 1 =  (iterable index)
+    IterNext, // u16 (jump if end)
     UnaryNegate,
     UnaryNot,
     UnarySpread,

--- a/src/backend/vm/compiler.rs
+++ b/src/backend/vm/compiler.rs
@@ -588,9 +588,7 @@ impl<Data> Compiler<Data> {
                 let start = self.level.function.chunk.len();
 
                 // IterNext takes (end jump u16) and assumes the loop context is on top of the stack
-                let data_offset = self.level.locals.len() - 2;
                 let exit = self.write_jump(OpCode::IterNext, *span);
-                self.write_u16(data_offset as u16, *span);
 
                 // pop off default none
                 self.write_op(OpCode::SwapPop, *span);
@@ -604,8 +602,7 @@ impl<Data> Compiler<Data> {
                 self.exit_scope(span);
 
                 self.write_jump_backward(start, *nspan)?;
-                // account for extra 2 op slots for the iternext
-                self.patch_jump_ex(exit, 2, *nspan)?;
+                self.patch_jump(exit, *nspan)?;
 
                 self.exit_scope(span);
             }
@@ -633,9 +630,7 @@ impl<Data> Compiler<Data> {
                 let start = self.level.function.chunk.len();
 
                 // IterNext takes (end jump u16) and assumes the loop context is on top of the stack
-                let data_offset = self.level.locals.len() - 2;
                 let exit = self.write_jump(OpCode::IterNext, *span);
-                self.write_u16(data_offset as u16, *span);
 
                 // pop default return
                 self.write_op(OpCode::SwapPop, *span);
@@ -652,8 +647,7 @@ impl<Data> Compiler<Data> {
                 self.exit_scope(span);
 
                 self.write_jump_backward(start, *span)?;
-                // account for extra 2 op slots for the iternext
-                self.patch_jump_ex(exit, 2, *span)?;
+                self.patch_jump(exit, *span)?;
 
                 // pop off the loop context
                 // self.write_op_u16(OpCode::PopMany, 2, *span);

--- a/src/backend/vm/vm.rs
+++ b/src/backend/vm/vm.rs
@@ -582,9 +582,11 @@ where
                     self.push(Value::__LoopCtx(0))?;
                 }
 
+                // stack[sp-3] contains loop ctx
+                // stack[sp-2] contains iterable
+                // stack[sp-1] contains previous loop iteration's value
                 IterNext => {
                     let exit_offset = self.read_u16() as usize;
-                    let data_offset = self.read_u16() as usize;
 
                     // let s = self.stack[0..self.sp]
                     //     .iter()
@@ -596,7 +598,7 @@ where
 
                     // println!("stack: {}",
                     let loop_idx = {
-                        let value = &self.stack[self.frame.st + data_offset];
+                        let value = &self.stack[self.sp - 3];
                         // println!("iter next: {}", value.display());
                         if let Value::__LoopCtx(loop_idx) = value {
                             *loop_idx
@@ -605,12 +607,12 @@ where
                         }
                     };
 
-                    if let Value::__LoopCtx(loop_idx) = &mut self.stack[self.frame.st + data_offset]
+                    if let Value::__LoopCtx(loop_idx) = &mut self.stack[self.sp - 3]
                     {
                         *loop_idx += 1;
                     }
 
-                    let iterable = &self.stack[self.frame.st + data_offset + 1];
+                    let iterable = &self.stack[self.sp - 2];
                     // println!("iterable: {}", iterable.display());
 
                     let value = match iterable {


### PR DESCRIPTION
IterNext is able to assumes the stack contains [loopctx, iterable, lastval] as the top 3 items (third to first) since the locals always get cleaned up after each iteration

Some ideas:
- pop the previous loop value so we don't need a SwapPop after IterNext
- test nested loops with locals
