### PR TITLE
swapped to 64bit numbers and vm options

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,4 +16,4 @@ disassembler = { path = "./disassembler" }
 opt-level = 3
 lto = "fat"
 codegen-units = 1
-# panic = "abort"
+panic = "abort"

--- a/common/src/error.rs
+++ b/common/src/error.rs
@@ -43,7 +43,7 @@ pub enum Error {
     SyntaxError(SyntaxError),
 
     #[error("index `{0}` out of bounds")]
-    IndexError(i32),
+    IndexError(i64),
 
     #[error("Division by zero")]
     ZeroDivisionError,

--- a/compiler/src/lib.rs
+++ b/compiler/src/lib.rs
@@ -971,8 +971,8 @@ pub fn literal_to_value(literal: &Literal) -> Value {
         Literal::Float(n) => Value::Float(*n),
         Literal::Color(c) => Value::Color(*c),
         Literal::String(s) => Value::String(Rc::new(s.clone())),
-        Literal::Array(arr) => Value::Array(Rc::new(Vecc::new_from(
-            arr.iter().map(literal_to_value).collect(),
+        Literal::Array(arr) => Value::Array(Rc::new(Vecc::force_new(
+            arr.iter().map(literal_to_value).collect::<Vec<Value>>(),
         ))),
         Literal::Pair(l, r) => Value::Pair(Rc::new((literal_to_value(l), literal_to_value(r)))),
         Literal::Range(s, e) => Value::Range(*s, *e),

--- a/interpreter/src/arith.rs
+++ b/interpreter/src/arith.rs
@@ -68,10 +68,10 @@ impl Value {
     // }
 
     #[inline]
-    pub fn add<const STRING_MAX_SIZE: usize>(&self, other: &Value) -> Result<Value, Error> {
+    pub fn add(&self, other: &Value, string_max_size: usize) -> Result<Value, Error> {
         match (self, other) {
             (Value::String(lhs), Value::String(rhs)) => {
-                if lhs.get_size() + rhs.get_size() > STRING_MAX_SIZE {
+                if lhs.get_size() + rhs.get_size() > string_max_size {
                     return Err(OverflowError::StringTooLarge.into());
                 }
 
@@ -79,8 +79,8 @@ impl Value {
             }
             (Value::Int(lhs), Value::Int(rhs)) => Ok(Value::Int(lhs + rhs)),
             (Value::Float(lhs), Value::Float(rhs)) => Ok(Value::Float(lhs + rhs)),
-            (Value::Int(lhs), Value::Float(rhs)) => Ok(Value::Float(*lhs as f32 + rhs)),
-            (Value::Float(lhs), Value::Int(rhs)) => Ok(Value::Float(lhs + *rhs as f32)),
+            (Value::Int(lhs), Value::Float(rhs)) => Ok(Value::Float(*lhs as f64 + rhs)),
+            (Value::Float(lhs), Value::Int(rhs)) => Ok(Value::Float(lhs + *rhs as f64)),
             (Value::Color(lhs), Value::Color(rhs)) => Ok(Value::Color([
                 lhs[0].saturating_add(rhs[0]),
                 lhs[1].saturating_add(rhs[1]),
@@ -101,8 +101,8 @@ impl Value {
         match (self, other) {
             (Value::Int(lhs), Value::Int(rhs)) => Ok(Value::Int(lhs - rhs)),
             (Value::Float(lhs), Value::Float(rhs)) => Ok(Value::Float(lhs - rhs)),
-            (Value::Int(lhs), Value::Float(rhs)) => Ok(Value::Float(*lhs as f32 - rhs)),
-            (Value::Float(lhs), Value::Int(rhs)) => Ok(Value::Float(lhs - *rhs as f32)),
+            (Value::Int(lhs), Value::Float(rhs)) => Ok(Value::Float(*lhs as f64 - rhs)),
+            (Value::Float(lhs), Value::Int(rhs)) => Ok(Value::Float(lhs - *rhs as f64)),
             (Value::Color(lhs), Value::Color(rhs)) => Ok(Value::Color([
                 lhs[0].saturating_sub(rhs[0]),
                 lhs[1].saturating_sub(rhs[1]),
@@ -119,7 +119,7 @@ impl Value {
     }
 
     #[inline]
-    pub fn multiply<const STRING_MAX_SIZE: usize>(&self, other: &Value) -> Result<Value, Error> {
+    pub fn multiply(&self, other: &Value, string_max_size: usize) -> Result<Value, Error> {
         match (self, other) {
             (Value::String(lhs), Value::Int(rhs)) => {
                 if *rhs < 0 {
@@ -135,7 +135,7 @@ impl Value {
                 let rhs = *rhs as usize;
 
                 // check if string is too long
-                if lhs.len() * rhs > STRING_MAX_SIZE {
+                if lhs.len() * rhs > string_max_size {
                     return Err(OverflowError::StringTooLarge.into());
                 }
 
@@ -143,8 +143,8 @@ impl Value {
             }
             (Value::Int(lhs), Value::Int(rhs)) => Ok(Value::Int(lhs * rhs)),
             (Value::Float(lhs), Value::Float(rhs)) => Ok(Value::Float(lhs * rhs)),
-            (Value::Int(lhs), Value::Float(rhs)) => Ok(Value::Float(*lhs as f32 * rhs)),
-            (Value::Float(lhs), Value::Int(rhs)) => Ok(Value::Float(lhs * *rhs as f32)),
+            (Value::Int(lhs), Value::Float(rhs)) => Ok(Value::Float(*lhs as f64 * rhs)),
+            (Value::Float(lhs), Value::Int(rhs)) => Ok(Value::Float(lhs * *rhs as f64)),
             (Value::Color(lhs), Value::Color(rhs)) => Ok(Value::Color([
                 lhs[0].saturating_mul(rhs[0]),
                 lhs[1].saturating_mul(rhs[1]),
@@ -171,8 +171,8 @@ impl Value {
             }
             (Value::Int(lhs), Value::Int(rhs)) => Ok(Value::Int(lhs / rhs)),
             (Value::Float(lhs), Value::Float(rhs)) => Ok(Value::Float(lhs / rhs)),
-            (Value::Int(lhs), Value::Float(rhs)) => Ok(Value::Float(*lhs as f32 / rhs)),
-            (Value::Float(lhs), Value::Int(rhs)) => Ok(Value::Float(lhs / *rhs as f32)),
+            (Value::Int(lhs), Value::Float(rhs)) => Ok(Value::Float(*lhs as f64 / rhs)),
+            (Value::Float(lhs), Value::Int(rhs)) => Ok(Value::Float(lhs / *rhs as f64)),
             (Value::Color(lhs), Value::Color(rhs)) => Ok(Value::Color([
                 lhs[0].saturating_div(rhs[0]),
                 lhs[1].saturating_div(rhs[1]),
@@ -196,8 +196,8 @@ impl Value {
         match (self, other) {
             (Value::Int(lhs), Value::Int(rhs)) => Ok(Value::Int(lhs % rhs)),
             (Value::Float(lhs), Value::Float(rhs)) => Ok(Value::Float(lhs % rhs)),
-            (Value::Int(lhs), Value::Float(rhs)) => Ok(Value::Float(*lhs as f32 % rhs)),
-            (Value::Float(lhs), Value::Int(rhs)) => Ok(Value::Float(lhs % *rhs as f32)),
+            (Value::Int(lhs), Value::Float(rhs)) => Ok(Value::Float(*lhs as f64 % rhs)),
+            (Value::Float(lhs), Value::Int(rhs)) => Ok(Value::Float(lhs % *rhs as f64)),
             _ => Err(TypeError::UnsupportedBinaryOperation {
                 op: "%",
                 lhs: self.ntype(),
@@ -212,8 +212,8 @@ impl Value {
         match (self, other) {
             (Value::Int(lhs), Value::Int(rhs)) => Ok(Value::Int(lhs.pow(*rhs as u32))),
             (Value::Float(lhs), Value::Float(rhs)) => Ok(Value::Float(lhs.powf(*rhs))),
-            (Value::Int(lhs), Value::Float(rhs)) => Ok(Value::Float((*lhs as f32).powf(*rhs))),
-            (Value::Float(lhs), Value::Int(rhs)) => Ok(Value::Float(lhs.powf(*rhs as f32))),
+            (Value::Int(lhs), Value::Float(rhs)) => Ok(Value::Float((*lhs as f64).powf(*rhs))),
+            (Value::Float(lhs), Value::Int(rhs)) => Ok(Value::Float(lhs.powf(*rhs as f64))),
             _ => Err(TypeError::UnsupportedBinaryOperation {
                 op: "**",
                 lhs: self.ntype(),
@@ -264,8 +264,8 @@ impl Value {
         match (self, other) {
             (Value::Int(lhs), Value::Int(rhs)) => Ok(Value::Bool(lhs > rhs)),
             (Value::Float(lhs), Value::Float(rhs)) => Ok(Value::Bool(lhs > rhs)),
-            (Value::Int(lhs), Value::Float(rhs)) => Ok(Value::Bool(*lhs as f32 > *rhs)),
-            (Value::Float(lhs), Value::Int(rhs)) => Ok(Value::Bool(*lhs > *rhs as f32)),
+            (Value::Int(lhs), Value::Float(rhs)) => Ok(Value::Bool(*lhs as f64 > *rhs)),
+            (Value::Float(lhs), Value::Int(rhs)) => Ok(Value::Bool(*lhs > *rhs as f64)),
             _ => Err(TypeError::UnsupportedBinaryOperation {
                 op: ">",
                 lhs: self.ntype(),
@@ -280,8 +280,8 @@ impl Value {
         match (self, other) {
             (Value::Int(lhs), Value::Int(rhs)) => Ok(Value::Bool(lhs >= rhs)),
             (Value::Float(lhs), Value::Float(rhs)) => Ok(Value::Bool(lhs >= rhs)),
-            (Value::Int(lhs), Value::Float(rhs)) => Ok(Value::Bool(*lhs as f32 >= *rhs)),
-            (Value::Float(lhs), Value::Int(rhs)) => Ok(Value::Bool(*lhs >= *rhs as f32)),
+            (Value::Int(lhs), Value::Float(rhs)) => Ok(Value::Bool(*lhs as f64 >= *rhs)),
+            (Value::Float(lhs), Value::Int(rhs)) => Ok(Value::Bool(*lhs >= *rhs as f64)),
             _ => Err(TypeError::UnsupportedBinaryOperation {
                 op: ">=",
                 lhs: self.ntype(),
@@ -296,8 +296,8 @@ impl Value {
         match (self, other) {
             (Value::Int(lhs), Value::Int(rhs)) => Ok(Value::Bool(lhs < rhs)),
             (Value::Float(lhs), Value::Float(rhs)) => Ok(Value::Bool(lhs < rhs)),
-            (Value::Int(lhs), Value::Float(rhs)) => Ok(Value::Bool((*lhs as f32) < *rhs)),
-            (Value::Float(lhs), Value::Int(rhs)) => Ok(Value::Bool(*lhs < *rhs as f32)),
+            (Value::Int(lhs), Value::Float(rhs)) => Ok(Value::Bool((*lhs as f64) < *rhs)),
+            (Value::Float(lhs), Value::Int(rhs)) => Ok(Value::Bool(*lhs < *rhs as f64)),
             _ => Err(TypeError::UnsupportedBinaryOperation {
                 op: "<",
                 lhs: self.ntype(),
@@ -312,8 +312,8 @@ impl Value {
         match (self, other) {
             (Value::Int(lhs), Value::Int(rhs)) => Ok(Value::Bool(lhs <= rhs)),
             (Value::Float(lhs), Value::Float(rhs)) => Ok(Value::Bool(lhs <= rhs)),
-            (Value::Int(lhs), Value::Float(rhs)) => Ok(Value::Bool(*lhs as f32 <= *rhs)),
-            (Value::Float(lhs), Value::Int(rhs)) => Ok(Value::Bool(*lhs <= *rhs as f32)),
+            (Value::Int(lhs), Value::Float(rhs)) => Ok(Value::Bool(*lhs as f64 <= *rhs)),
+            (Value::Float(lhs), Value::Int(rhs)) => Ok(Value::Bool(*lhs <= *rhs as f64)),
             _ => Err(TypeError::UnsupportedBinaryOperation {
                 op: "<=",
                 lhs: self.ntype(),
@@ -337,10 +337,15 @@ impl Value {
     }
 
     #[inline]
-    pub fn join<const STRING_MAX_SIZE: usize>(&self, other: &Value) -> Result<Value, Error> {
+    pub fn join(
+        &self,
+        other: &Value,
+        string_max_size: usize,
+        array_max_size: usize,
+    ) -> Result<Value, Error> {
         match (self, other) {
             (Value::String(lhs), Value::String(rhs)) => {
-                if lhs.get_size() + rhs.get_size() > STRING_MAX_SIZE {
+                if lhs.get_size() + rhs.get_size() > string_max_size {
                     return Err(OverflowError::StringTooLarge.into());
                 }
 
@@ -349,7 +354,7 @@ impl Value {
             (Value::String(lhs), Value::Int(rhs)) => {
                 let rhs = rhs.to_string();
 
-                if lhs.get_size() + rhs.get_size() > STRING_MAX_SIZE {
+                if lhs.get_size() + rhs.get_size() > string_max_size {
                     return Err(OverflowError::StringTooLarge.into());
                 }
 
@@ -358,7 +363,7 @@ impl Value {
             (Value::String(lhs), Value::Float(rhs)) => {
                 let rhs = rhs.to_string();
 
-                if lhs.get_size() + rhs.get_size() > STRING_MAX_SIZE {
+                if lhs.get_size() + rhs.get_size() > string_max_size {
                     return Err(OverflowError::StringTooLarge.into());
                 }
 
@@ -367,7 +372,7 @@ impl Value {
             (Value::String(lhs), Value::Bool(rhs)) => {
                 let rhs = rhs.to_string();
 
-                if lhs.get_size() + rhs.get_size() > STRING_MAX_SIZE {
+                if lhs.get_size() + rhs.get_size() > string_max_size {
                     return Err(OverflowError::StringTooLarge.into());
                 }
 
@@ -376,7 +381,7 @@ impl Value {
             (Value::String(lhs), Value::None) => {
                 let rhs = "none".to_string();
 
-                if lhs.get_size() + rhs.get_size() > STRING_MAX_SIZE {
+                if lhs.get_size() + rhs.get_size() > string_max_size {
                     return Err(OverflowError::StringTooLarge.into());
                 }
 
@@ -385,7 +390,7 @@ impl Value {
             (Value::Int(lhs), Value::String(rhs)) => {
                 let lhs = lhs.to_string();
 
-                if lhs.get_size() + rhs.get_size() > STRING_MAX_SIZE {
+                if lhs.get_size() + rhs.get_size() > string_max_size {
                     return Err(OverflowError::StringTooLarge.into());
                 }
 
@@ -394,7 +399,7 @@ impl Value {
             (Value::Float(lhs), Value::String(rhs)) => {
                 let lhs = lhs.to_string();
 
-                if lhs.get_size() + rhs.get_size() > STRING_MAX_SIZE {
+                if lhs.get_size() + rhs.get_size() > string_max_size {
                     return Err(OverflowError::StringTooLarge.into());
                 }
 
@@ -403,7 +408,7 @@ impl Value {
             (Value::Bool(lhs), Value::String(rhs)) => {
                 let lhs = lhs.to_string();
 
-                if lhs.get_size() + rhs.get_size() > STRING_MAX_SIZE {
+                if lhs.get_size() + rhs.get_size() > string_max_size {
                     return Err(OverflowError::StringTooLarge.into());
                 }
 
@@ -412,14 +417,14 @@ impl Value {
             (Value::None, Value::String(rhs)) => {
                 let lhs = "none".to_string();
 
-                if lhs.get_size() + rhs.get_size() > STRING_MAX_SIZE {
+                if lhs.get_size() + rhs.get_size() > string_max_size {
                     return Err(OverflowError::StringTooLarge.into());
                 }
 
                 Ok(Value::String(Rc::new(lhs + rhs)))
             }
             (Value::Array(lhs), Value::Array(rhs)) => {
-                if lhs.get_size() + rhs.get_size() > Self::ARRAY_MAX_SIZE {
+                if lhs.get_size() + rhs.get_size() > array_max_size {
                     return Err(OverflowError::ArrayTooLarge.into());
                 }
 
@@ -450,9 +455,9 @@ impl Value {
 
 // boundary checks
 // wraps negatives around
-pub fn fix_index(idx: i32, len: usize) -> Result<usize, Error> {
+pub fn fix_index(idx: i64, len: usize) -> Result<usize, Error> {
     let index = if idx < 0 {
-        if -idx > len as i32 {
+        if -idx > len as i64 {
             Err(Error::IndexError(idx))?
         } else {
             len + idx as usize

--- a/parser/src/literal.rs
+++ b/parser/src/literal.rs
@@ -14,8 +14,8 @@
 pub enum Literal {
     None,
     Bool(bool),
-    Int(i32),
-    Float(f32),
+    Int(i64),
+    Float(f64),
     Range(i32, i32),
     Color([u8; 4]),
 

--- a/parser/src/parser.rs
+++ b/parser/src/parser.rs
@@ -35,11 +35,15 @@ peg::parser!(
         }}
         / expected!("identifier")
 
-        rule INT() -> i32
+        rule INT() -> i64
         = quiet!{ i:$("-"?['0'..='9']+) { i.parse().unwrap_or(0) } }
         / expected!("integer")
 
-        rule FLOAT() -> f32
+        rule INT32() -> i32
+        = quiet!{ i:$("-"?['0'..='9']+) { i.parse().unwrap_or(0) } }
+        / expected!("integer")
+
+        rule FLOAT() -> f64
         = quiet!{  i:$("-"?['0'..='9']+ "." !"." ['0'..='9']*)  { i.parse().unwrap_or(0.0) } }
         / expected!("float")
 
@@ -67,7 +71,7 @@ peg::parser!(
         / KW("none") { Literal::None }
         / h:HEX() { Literal::Color(h) }
         / f:FLOAT() { Literal::Float(f) }
-        / s:INT() _ ":" _ e:INT() { Literal::Range(s, e) }
+        / s:INT32() _ ":" _ e:INT32() { Literal::Range(s, e) }
         / i:INT() { Literal::Int(i) }
         / s:STRING() { Literal::String(s) }
         / "(" _ h:literal() _ "," _ t:literal() _ ")" { Literal::Pair(Box::new(h), Box::new(t)) }
@@ -140,7 +144,7 @@ peg::parser!(
             --
             KW("include") _ s:spanned(<STRING()>) { Node::Include(s, None) }
             --
-            s:INT() _ ":" _ e:INT() { Node::Literal(Literal::Range(s, e)) }
+            s:INT32() _ ":" _ e:INT32() { Node::Literal(Literal::Range(s, e)) }
             x:(@) _ ":" _ y:@ { Node::Range(Box::new(x), Box::new(y)) }
             --
             x:(@) _ "&&" _ y:@ { Node::Binary(Op::And, Box::new(x), Box::new(y)) }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -10,7 +10,7 @@ pub mod prelude {
     pub use interpreter::builtins::{error, error_with_help, expected, Consumable, VmData};
     pub use interpreter::qstd;
     pub use interpreter::value::Value;
-    pub use interpreter::vm::VM;
+    pub use interpreter::vm::{VmOptions, VM};
     pub use interpreter::Script;
 
     pub use interpreter::context_builtins;

--- a/src/tests/mod.rs
+++ b/src/tests/mod.rs
@@ -12,7 +12,13 @@ fn test_code<const SS: usize, const CSS: usize>(
 
     let script = Compiler::compile(&ast)?;
 
-    let mut vm = VM::<SS, CSS>::new((), script);
+    let mut vm = VM::new(
+        (),
+        script,
+        VmOptions::build()
+            .with_stack_size(SS)
+            .with_call_stack_size(CSS),
+    );
     vm.add_builtins(qstd::io);
     vm.add_builtins(qstd::math);
     vm.add_builtins(qstd::core);


### PR DESCRIPTION
- using 64bit floats and ints instead of 32
- swapped const generics for a `VmOptions` struct
- callstack moved to the heap
- much larger default VM options